### PR TITLE
Upgrade log4j dependency (CVE-2021-44228, CVE-2021-45046)

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -15,3 +15,12 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform() 
 }
+// Force usage of log4j dependencies that are not vulnerable to CVE-2021-44228. #upgrade-log4j-gradle-cve-2021-44228
+configurations.all {
+  resolutionStrategy.eachDependency { details ->
+    if (details.target.group == 'org.apache.logging.log4j' && details.target.version < '2.16.0') {
+      details.useVersion '2.16.0'
+      details.because 'CVE-2021-44228'
+    }
+  }
+}


### PR DESCRIPTION
Upgrades log4j to a version not affected by vulnerability

[_Created by Sourcegraph batch change `dan.diemer/upgrade-log4j-2.16-gradle`._](https://demo.sourcegraph.com/users/dan.diemer/batch-changes/upgrade-log4j-2.16-gradle)